### PR TITLE
Fix syntax warning

### DIFF
--- a/modules/transmission.py
+++ b/modules/transmission.py
@@ -191,7 +191,7 @@ class Transmission(object):
             self.logger.info('Added %s to Transmission' % torrentname)
             return self.fetch('torrent-add', {'filename': link})
         except Exception as e:
-            self.logger.debug('Failed to add %s to Transmission %s %s'(torrentname, link, e))
+            self.logger.debug('Failed to add %s to Transmission %s %s' % (torrentname, link, e))
 
     # Wrapper to access the Transmission Api
     # If the first call fails, there probably is no valid Session ID so we try it again


### PR DESCRIPTION
Python3.8 throws: "`/modules/transmission.py:194: SyntaxWarning: 'str' object is not callable; perhaps you missed a comma?`"
However, the actual syntax issue is the missing "`%`" here. Adding it solves the warning as well.

**Note:**
Python3.8 fails later for a different reason:
```
Aug 25 19:38:01 VM-Bullseye python3[3322]: Traceback (most recent call last):
Aug 25 19:38:01 VM-Bullseye python3[3322]:   File "/mnt/dietpi_userdata/htpc-manager/Htpc.py", line 269, in <module>
Aug 25 19:38:01 VM-Bullseye python3[3322]:     main()
Aug 25 19:38:01 VM-Bullseye python3[3322]:   File "/mnt/dietpi_userdata/htpc-manager/Htpc.py", line 266, in main
Aug 25 19:38:01 VM-Bullseye python3[3322]:     start()
Aug 25 19:38:01 VM-Bullseye python3[3322]:   File "/mnt/dietpi_userdata/htpc-manager/htpc/server.py", line 191, in start
Aug 25 19:38:01 VM-Bullseye python3[3322]:     logger.info("Starting up webserver")
Aug 25 19:38:01 VM-Bullseye python3[3322]:   File "/usr/lib/python3.8/logging/__init__.py", line 1434, in info
Aug 25 19:38:01 VM-Bullseye python3[3322]:     self._log(INFO, msg, args, **kwargs)
Aug 25 19:38:01 VM-Bullseye python3[3322]:   File "/usr/lib/python3.8/logging/__init__.py", line 1565, in _log
Aug 25 19:38:01 VM-Bullseye python3[3322]:     fn, lno, func, sinfo = self.findCaller(stack_info, stacklevel)
Aug 25 19:38:01 VM-Bullseye python3[3322]: TypeError: findCaller() takes from 1 to 2 positional arguments but 3 were given
```
Played around with it but was not able to fix it, I'm no Python programmer so reading a bid though Python3.8 logging docs and comparing with other scripts/examples was the only thing I could do, but that didn't help. I guess it has to do with object instantiation. Searching through the web shows many similar cases but I was not able to extract a solution that does not involve updating the module that causes the error 😄. Updating all modules btw as well doesn't solve it, reasonably since this involves only the Python-internal logging functionality.